### PR TITLE
expose OrtError, add SessionGet{In,Out}putName

### DIFF
--- a/hs-onnxruntime-capi-test/test/Test/Onnxruntime/CApi.hs
+++ b/hs-onnxruntime-capi-test/test/Test/Onnxruntime/CApi.hs
@@ -94,11 +94,9 @@ test_ortApiRun = do
         ortSession <- ortApiCreateSession ortEnv modelPath ortSessionOptions
         -- Create OrtRunOptions
         ortRunOptions <- ortApiCreateRunOptions ortApi
-        -- Create OrtMemoryInfo
-        ortMemoryInfo <- ortApiCreateCpuMemoryInfo ortApi OrtDeviceAllocator OrtMemTypeDefault
         -- Create input OrtValue
         let input1Data = VS.fromList [10, 10] :: Vector Float
-        ortApiWithTensorWithDataAsOrtValue ortMemoryInfo input1Data [1, 2] $ \input1 -> do
+        ortApiWithTensorWithDataAsOrtValue ortApi input1Data [1, 2] $ \input1 -> do
             -- Run
             let inputNames = ["input_1"]
             let outputNames = ["dense_3"]

--- a/hs-onnxruntime-capi-test/test/Test/Onnxruntime/CApi.hs
+++ b/hs-onnxruntime-capi-test/test/Test/Onnxruntime/CApi.hs
@@ -36,6 +36,7 @@ test_ortApiGetModelTypeInfo = do
         -- Get OrtApi
         ortApiBase <- ortGetApiBase
         ortApi <- ortApiBaseGetApi ortApiBase ortApiVersion
+        allocator <- ortApiGetAllocatorWithDefaultOptions ortApi
         -- Create OrtEnv
         let logid = "test_ortApiRun"
         ortEnv <- ortApiCreateEnv ortApi OrtLoggingLevelFatal logid
@@ -58,6 +59,8 @@ test_ortApiGetModelTypeInfo = do
             inputDims @?= [1, 2]
             inputTensorElementType <- ortApiGetTensorElementType inputTypeAndShape
             inputTensorElementType @?= ONNXTensorElementDataTypeFloat
+            inputName <- ortApiSessionGetInputName ortSession inputIndex allocator
+            inputName @?= "input_1"
         -- Get the model output type and shape info
         outputCount <- ortApiSessionGetOutputCount ortSession
         outputCount @?= 1
@@ -70,6 +73,8 @@ test_ortApiGetModelTypeInfo = do
             outputDims @?= [1, 1]
             outputTensorElementType <- ortApiGetTensorElementType outputTypeAndShape
             outputTensorElementType @?= ONNXTensorElementDataTypeFloat
+            outputName <- ortApiSessionGetOutputName ortSession outputIndex allocator
+            outputName @?= "dense_3"
 
 test_ortApiRun :: TestTree
 test_ortApiRun = do

--- a/hs-onnxruntime-capi/src/Onnxruntime/CApi.hsc
+++ b/hs-onnxruntime-capi/src/Onnxruntime/CApi.hsc
@@ -70,6 +70,11 @@ module Onnxruntime.CApi
       OrtDeviceAllocator,
       OrtArenaAllocator
     ),
+    OrtError (
+      OrtError,
+      ortErrorCode,
+      ortErrorMessage
+    ),
     OrtErrorCode (
       OrtOk,
       OrtFail,

--- a/hs-onnxruntime-capi/src/Onnxruntime/CApi.hsc
+++ b/hs-onnxruntime-capi/src/Onnxruntime/CApi.hsc
@@ -3642,13 +3642,13 @@ foreign import capi unsafe
 ortApiWithTensorWithDataAsOrtValue ::
   forall a b.
   (IsONNXTensorElementDataType a) =>
-  OrtMemoryInfo ->
+  OrtApi ->
   Vector a ->
   [Int64] ->
   (OrtValue -> IO b) ->
   IO b
-ortApiWithTensorWithDataAsOrtValue memoryInfo values shape action = do
-  ortApi <- getOrtApi memoryInfo
+ortApiWithTensorWithDataAsOrtValue ortApi values shape action = do
+  memoryInfo <- ortApiCreateCpuMemoryInfo ortApi OrtDeviceAllocator OrtMemTypeCPU
   withCTypePtr memoryInfo $ \cOrtMemoryInfoPtr -> do
     let valueLen = VS.length values
     VS.unsafeWith values $ \valuePtr -> do


### PR DESCRIPTION
Please see the individual commit messages for motivation. Most code is generated with LLMs but carefully reviewed.

Note that I would highly prefer this library switches to an LGPL license, otherwise I can't actually use it. See #6.

- [ ] Since this starts using `ortApiGetAllocatorWithDefaultOptions`, #9 needs to be fixed first.